### PR TITLE
get_host is now not in that location

### DIFF
--- a/django_cas/views.py
+++ b/django_cas/views.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from urllib import urlencode
 from urlparse import urljoin
 from django.contrib import messages
-from django.http import get_host, HttpResponseRedirect, HttpResponseForbidden, HttpResponse
+from django.http import HttpResponseRedirect, HttpResponseForbidden, HttpResponse
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django_cas.models import PgtIOU
@@ -14,7 +14,7 @@ def _service_url(request, redirect_to=None):
     """Generates application service URL for CAS"""
 
     protocol = ('http://', 'https://')[request.is_secure()]
-    host = get_host(request)
+    host = request.get_host()
     service = protocol + host + request.path
     if redirect_to:
         if '?' in service:
@@ -111,9 +111,9 @@ def logout(request, next_page=None):
 
 def proxy_callback(request):
     """Handles CAS 2.0+ XML-based proxy callback call.
-    Stores the proxy granting ticket in the database for 
+    Stores the proxy granting ticket in the database for
     future use.
-    
+
     NB: Use created and set it in python in case database
     has issues with setting up the default timestamp value
     """


### PR DESCRIPTION
Looks like django 1.5 they moved get_host and its only accesable from the request object. Seems like older version of django do this too. 
